### PR TITLE
Point to new Nengo core doc location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@
 NengoDL: Deep learning integration for Nengo
 ********************************************
 
-NengoDL is a simulator for `Nengo <https://pythonhosted.org/nengo/>`_ models.
+NengoDL is a simulator for `Nengo <http://www.nengo.ai/nengo/>`_ models.
 That means it takes a Nengo network as input, and allows the user to simulate
 that network using some underlying computational framework (in this case,
 `TensorFlow <https://www.tensorflow.org/>`_).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ autodoc_member_order = 'bysource'  # default is alphabetical
 # -- sphinx.ext.intersphinx
 intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
-    'nengo': ('http://pythonhosted.org/nengo', None),
+    'nengo': ('http://www.nengo.ai/nengo/', None),
 }
 
 # -- sphinx.ext.todo

--- a/docs/extra_objects.rst
+++ b/docs/extra_objects.rst
@@ -9,7 +9,7 @@ Neuron types
 ------------
 
 Additions to the `neuron types included with Nengo
-<https://pythonhosted.org/nengo/frontend_api.html#neuron-types>`_.
+<http://www.nengo.ai/nengo/frontend_api.html#neuron-types>`_.
 
 .. automodule:: nengo_dl.neurons
 
@@ -17,7 +17,7 @@ Distributions
 -------------
 
 Additions to the `distributions included with Nengo
-<https://pythonhosted.org/nengo/frontend_api.html#distributions>`_.  These
+<http://www.nengo.ai/nengo/frontend_api.html#distributions>`_.  These
 distributions are usually used to initialize weight matrices, e.g.
 ``nengo.Connection(a.neurons, b.neurons, transform=nengo_dl.dists.Glorot())``.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ To install NengoDL, we recommend using ``pip``:
 ``pip`` will do its best to install all of NengoDL's requirements when it
 installs NengoDL.  However, if anything goes wrong during this process you
 can install the requirements manually.  See the
-`Nengo documentation <https://pythonhosted.org/nengo/getting_started.html>`_
+`Nengo documentation <http://www.nengo.ai/download.html>`_
 for instructions on installing ``numpy`` and ``nengo``, and the ``tensorflow``
 installation instructions below.
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1,7 +1,7 @@
 Additional resources
 ====================
 
-- `Nengo documentation <https://pythonhosted.org/nengo/>`_: If you are new to
+- `Nengo documentation <http://www.nengo.ai/>`_: If you are new to
   Nengo, you should start here.
 
 - `Nengo forums <https://forum.nengo.ai/>`_: To get help or ask questions about

--- a/docs/training.rst
+++ b/docs/training.rst
@@ -17,7 +17,7 @@ important features of NengoDL.  This functionality is accessed via the
 When the ``Simulator`` is first constructed, all the parameters in the model
 (e.g., encoders, decoders, connection weights, biases) are initialized based
 on the functions/distributions specified during model construction (see the
-`Nengo documentation <https://pythonhosted.org/nengo/>`_ for more detail on
+`Nengo documentation <http://www.nengo.ai/nengo/>`_ for more detail on
 how that works).  What the :meth:`.Simulator.train` method does is then
 further optimize those parameters based on some inputs and desired
 outputs.  We'll go through each of those components in more detail
@@ -200,7 +200,7 @@ with each other, likely resulting in unintended effects.  So NengoDL will
 assume that those elements should not be optimized.
 
 Any of these default behaviours can be overriden using `Nengo's config system
-<https://pythonhosted.org/nengo/config.html>`_.  Specifically, setting the
+<http://www.nengo.ai/nengo/config.html>`_.  Specifically, setting the
 ``trainable`` config attribute for an object will control whether or not it
 will be optimized.
 


### PR DESCRIPTION
See https://github.com/nengo/nengo/pull/1338 for details.