### PR TITLE
Ensure signal ordering is deterministic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Release History
 **Fixed**
 
 - ``sim.data`` now implements the full ``collections.Mapping`` interface
+- Fixed bug where signal order was non-deterministic for Networks containing
+  objects with duplicate names
+  (`#9 <https://github.com/nengo/nengo_dl/issues/9>`_)
 
 0.5.1 (August 28, 2017)
 -----------------------

--- a/nengo_dl/graph_optimizer.py
+++ b/nengo_dl/graph_optimizer.py
@@ -620,9 +620,12 @@ def order_signals(plan, n_passes=10):
         of signals
     """
 
-    # get all the unique base signals
-    all_signals = sorted(set([s.base for ops in plan for op in ops
-                              for s in op.all_signals]), key=lambda s: s.name)
+    # get all the unique base signals (we use OrderedDict to drop the duplicate
+    # bases without changing their order, so that signal order will be
+    # deterministic for a given model)
+    all_signals = list(OrderedDict(
+        [(s.base, None) for ops in plan for op in ops
+         for s in op.all_signals]).keys())
 
     # figure out all the read blocks in the plan (in theory we would like each
     # block to become a contiguous chunk in the base array)


### PR DESCRIPTION
Fixes #9 

The problem was that we were ordering signals based on their label, so for networks containing objects with the same name (e.g., the two Nodes with label "square" in the Product network) that order was non-deterministic.

This changes it so that we sort signals based on their position in the op plan, which should be deterministic for a given Network.