### PR TITLE
Update link to tensorflow/models/research

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ Release History
   (`#9 <https://github.com/nengo/nengo_dl/issues/9>`_)
 - Fixed bug where non-slot optimizer variables were not initialized
   (`#11 <https://github.com/nengo/nengo_dl/issues/11>`_)
+- Implemented a modified PES builder in order to avoid slicing encoders on
+  non-decoded PES connections
 
 0.5.1 (August 28, 2017)
 -----------------------

--- a/docs/examples/pretrained_model.ipynb
+++ b/docs/examples/pretrained_model.ipynb
@@ -52,7 +52,7 @@
    "outputs": [],
    "source": [
     "!git clone https://github.com/tensorflow/models\n",
-    "sys.path.append(os.path.join(\".\", \"models\", \"slim\"))\n",
+    "sys.path.append(os.path.join(\".\", \"models\", \"research\", \"slim\"))\n",
     "from datasets import dataset_utils, imagenet\n",
     "from nets import inception\n",
     "from preprocessing import inception_preprocessing"

--- a/nengo_dl/graph_optimizer.py
+++ b/nengo_dl/graph_optimizer.py
@@ -1187,9 +1187,9 @@ def create_signals(sigs, plan, float_type, minibatch_size):
             sig_map[sig] = sig_map[sig.base].reshape(sig.shape)
         else:
             if sig.shape[1:] != sig.base.shape[1:]:
+                # TODO: support this?
                 raise NotImplementedError(
-                    "Slicing and reshaping the same signal is not "
-                    "supported")
+                    "Slicing on axes > 0 is not supported")
 
             # slice view
             assert np.all([x == 1 for x in sig.elemstrides[1:]])


### PR DESCRIPTION
This fixes things on our end, but there is still an error because there are a lot of broken links in the `tensorflow/models` repo after the refactoring.  Should work once https://github.com/tensorflow/models/pull/2439 is merged.