### PR TITLE
Output summary data during training

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Release History
   executed after the simulation is initialized (see the `TensorNode
   documentation for details
   <https://www.nengo.ai/nengo_dl/tensor_node.html>`_).
+- Added functionality for outputting summary data during the training process
+  that can be viewed in TensorBoard (see the `sim.train documentation
+  <https://www.nengo.ai/nengo_dl/training.html>`__).
 
 **Changed**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,7 @@ source_suffix = '.rst'
 source_encoding = 'utf-8'
 master_doc = 'index'
 suppress_warnings = ['image.nonlocal_uri']
+linkcheck_ignore = [r'http://localhost:\d+']
 
 project = u'NengoDL'
 authors = u'Applied Brain Research'

--- a/docs/simulator.rst
+++ b/docs/simulator.rst
@@ -108,18 +108,27 @@ from the training data will be used for each optimization iteration.
 tensorboard
 ^^^^^^^^^^^
 
-If set to ``True``, ``nengo_dl`` will save the structure of the internal
-simulation graph so that it can be visualized in `TensorBoard
-<https://www.tensorflow.org/get_started/graph_viz>`_.  This is mainly useful
-to developers trying to debug the simulator.  This data is stored in the
-``<nengo_dl>/data`` folder, and can be loaded via
+This can be used to specify an output directory if you would like to export
+data from the simulation in a format that can be visualized in
+`TensorBoard <https://www.tensorflow.org/get_started/summaries_and_tensorboard>`_.
+
+To view the collected data, run the command
 
 .. code-block:: bash
 
-    tensorboard --logdir <path/to/nengo_dl>
+    tensorboard --logdir <tensorboard_dir>
 
-Data will be organized according to the :class:`~nengo:nengo.Network` label
-and run number.
+(where ``tensorboard_dir`` is the directory name passed to ``tensorboard``),
+then open a web browser and navigate to http://localhost:6006.
+
+By default the TensorBoard output will only contain a `visualization of the
+TensorFlow graph <https://www.tensorflow.org/get_started/graph_viz>`_
+constructed for this Simulator.  However, TensorBoard can also be used to track
+various aspects of the simulation throughout the training process; see
+:ref:`the documentation <summaries>` for details.
+
+Repeated Simulator calls with the same output directory will be organized into
+subfolders according to run number (e.g., ``<tensorboard_dir>/run_0``).
 
 .. _sim-run:
 

--- a/docs/training.rst
+++ b/docs/training.rst
@@ -26,7 +26,7 @@ below.
 Simulator.train arguments
 -------------------------
 
-Inputs
+inputs
 ^^^^^^
 
 The first argument to the :meth:`.Simulator.train` function is the input data.
@@ -77,7 +77,7 @@ will take on the values specified during model construction.  Also note that
 inputs can only be defined for Nodes with no incoming connections (i.e., Nodes
 with ``size_in == 0``).
 
-Targets
+targets
 ^^^^^^^
 
 Returning to the network equation :math:`y = f(x, \theta)`, the goal in
@@ -115,7 +115,7 @@ In practice we would do something like ``targets={p: my_func(inputs)}``, where
 ``my_func`` is a function specifying what the ideal outputs are for the given
 inputs.
 
-Optimizer
+optimizer
 ^^^^^^^^^
 
 The optimizer is the algorithm that defines how to update the
@@ -136,7 +136,7 @@ arguments required by that optimizer), and that instance is then passed to
         sim.train(optimizer=tf.train.MomentumOptimizer(
             learning_rate=1e-2, momentum=0.9, use_nesterov=True), ...)
 
-Objective
+objective
 ^^^^^^^^^
 
 The goal in optimization is to minimize the error between the network's actual
@@ -173,6 +173,51 @@ error value.
 
 Note that :meth:`.Simulator.loss` can be used to check the loss
 (error) value for a given objective.
+
+.. _summaries:
+
+summaries
+^^^^^^^^^
+
+It is often useful to view information about how aspects of a model are
+changing over the course of training.  TensorFlow has created `TensorBoard
+<https://www.tensorflow.org/get_started/summaries_and_tensorboard>`_ to help
+visualize this kind of data, and the ``summaries`` argument can be used to
+specify the model data that you would like to export for TensorBoard.
+
+It is specified as a dictionary with the form ``{label: obj, ...}`` where each
+element defines a plot label as well as the object for which we want to collect
+data.  The data collected depends on the object: if it is a
+:class:`~nengo:nengo.Connection` then data will be collected about the
+distribution of the connection weights over the course of training; passing an
+:class:`~nengo:nengo.Ensemble` will collect data about the distribution of
+encoders, and :class:`~nengo:nengo.ensemble.Neurons` will collect data about
+the distribution of biases. Additionally, the string ``"loss"`` can be passed
+for ``obj``, in which case the training error for the given objective will be
+collected over the course of training.
+
+TensorBoard can be used to view the exported data via the command
+
+.. code-block:: bash
+
+    tensorboard --logdir <tensorboard_dir>
+
+where ``tensorboard_dir`` is the value specified on Simulator creation via
+``nengo_dl.Simulator(..., tensorboard=tensorboard_dir)``.  After TensorBoard is
+running you can view the data by opening a web browser and navigating to
+http://localhost:6006.
+
+For details on the usage of TensorBoard, consult the `TensorFlow documentation
+<https://www.tensorflow.org/get_started/summaries_and_tensorboard>`__.
+However, as a brief summary, you will find plots showing the loss values over
+the course of training in the ``Scalars`` tab at the top, and plots showing the
+distributions of weights/encoders/biases over time in the ``Distributions`` or
+``Histograms`` tabs.  If you call ``sim.train`` several times with the same
+summaries, each call will result in its own set of plots, with a suffix added
+to the label indicating the call number (e.g. ``label, label_1, label_2,
+...``). If you run your code multiple times with the same ``tensorboard_dir``,
+data will be organized according to run number; you can turn on/off the plots
+for different runs using the checkboxes in the bottom left.
 
 Other parameters
 ^^^^^^^^^^^^^^^^

--- a/nengo_dl/benchmarks.py
+++ b/nengo_dl/benchmarks.py
@@ -16,11 +16,11 @@ def cconv(dimensions, neurons_per_d, neuron_type):
     Parameters
     ----------
     dimensions : int
-        number of dimensions for vector values
+        Number of dimensions for vector values
     neurons_per_d : int
-        number of neurons to use per vector dimension
+        Number of neurons to use per vector dimension
     neuron_type : :class:`~nengo:nengo.neurons.NeuronType`
-        simulation neuron type
+        Simulation neuron type
 
     Returns
     -------
@@ -51,11 +51,11 @@ def integrator(dimensions, neurons_per_d, neuron_type):
     Parameters
     ----------
     dimensions : int
-        number of dimensions for vector values
+        Number of dimensions for vector values
     neurons_per_d : int
-        number of neurons to use per vector dimension
+        Number of neurons to use per vector dimension
     neuron_type : :class:`~nengo:nengo.neurons.NeuronType`
-        simulation neuron type
+        Simulation neuron type
 
     Returns
     -------
@@ -85,11 +85,11 @@ def pes(dimensions, neurons_per_d, neuron_type):
     Parameters
     ----------
     dimensions : int
-        number of dimensions for vector values
+        Number of dimensions for vector values
     neurons_per_d : int
-        number of neurons to use per vector dimension
+        Number of neurons to use per vector dimension
     neuron_type : :class:`~nengo:nengo.neurons.NeuronType`
-        simulation neuron type
+        Simulation neuron type
 
     Returns
     -------
@@ -125,7 +125,7 @@ def compare_backends(raw=False):
     Parameters
     ----------
     raw : bool
-        if True, run the benchmarks to collect data, otherwise load data from
+        If True, run the benchmarks to collect data, otherwise load data from
         file
     """
 

--- a/nengo_dl/builder.py
+++ b/nengo_dl/builder.py
@@ -21,9 +21,9 @@ class Builder(object):
         Parameters
         ----------
         ops : tuple of :class:`~nengo:nengo.builder.Operator`
-            the operator group to build into the model
+            The operator group to build into the model
         signals : :class:`.signals.SignalDict`
-            mapping from :class:`~nengo:nengo.builder.Signal` to
+            Mapping from :class:`~nengo:nengo.builder.Signal` to
             ``tf.Tensor`` (updated by operations)
         op_builds : dict of {tuple of :class:`~nengo.builder.Operator`, \
                              :class:~`.op_builders.OpBuilder`}
@@ -53,13 +53,13 @@ class Builder(object):
         Parameters
         ----------
         ops : tuple of :class:`~nengo:nengo.builder.Operator`
-            the operator group to build into the model
+            The operator group to build into the model
         signals : :class:`.signals.SignalDict`
-            mapping from :class:`~nengo:nengo.builder.Signal` to
+            Mapping from :class:`~nengo:nengo.builder.Signal` to
             ``tf.Tensor`` (updated by operations)
         op_builds : dict of {tuple of :class:`~nengo.builder.Operator`, \
                              :class:~`.op_builders.OpBuilder`}
-            mapping from operator groups to the pre-built builder objects
+            Mapping from operator groups to the pre-built builder objects
         """
 
         logger.debug("===================")
@@ -109,9 +109,9 @@ class OpBuilder(object):  # pragma: no cover
     Parameters
     ----------
     ops : list of :class:`~nengo:nengo.builder.Operator`
-        the operator group to build into the model
+        The operator group to build into the model
     signals : :class:`.signals.SignalDict`
-        mapping from :class:`~nengo:nengo.builder.Signal` to
+        Mapping from :class:`~nengo:nengo.builder.Signal` to
         ``tf.Tensor`` (updated by operations)
     """
 
@@ -125,15 +125,15 @@ class OpBuilder(object):  # pragma: no cover
         Parameters
         ----------
         signals : :class:`.signals.SignalDict`
-            mapping from :class:`~nengo:nengo.builder.Signal` to
+            Mapping from :class:`~nengo:nengo.builder.Signal` to
             ``tf.Tensor`` (updated by operations)
 
         Returns
         -------
         list of ``tf.Tensor``, optional
-            if not None, the returned tensors correspond to outputs with
+            If not None, the returned tensors correspond to outputs with
             possible side-effects, i.e. computations that need to be executed
-            in the tensorflow graph even if their output doesn't appear to be
+            in the TensorFlow graph even if their output doesn't appear to be
             used
         """
         raise BuildError("OpBuilders must implement a `build_step` function")
@@ -150,13 +150,13 @@ class OpBuilder(object):  # pragma: no cover
         Parameters
         ----------
         ops : list of :class:`~nengo:nengo.builder.Operator`
-            the operator group to build into the model
+            The operator group to build into the model
         signals : :class:`.signals.SignalDict`
-            mapping from :class:`~nengo:nengo.builder.Signal` to
+            Mapping from :class:`~nengo:nengo.builder.Signal` to
             ``tf.Tensor`` (updated by operations)
         sess : ``tf.Session``
-            the initialized simulation session
+            The initialized simulation session
         rng : :class:`~numpy:numpy.random.RandomState`
-            seeded random number generator
+            Seeded random number generator
         """
         pass

--- a/nengo_dl/dists.py
+++ b/nengo_dl/dists.py
@@ -12,12 +12,12 @@ class TruncatedNormal(Distribution):
     Parameters
     ----------
     mean : float, optional
-        mean of the normal distribution
+        Mean of the normal distribution
     stddev : float, optional
-        standard deviation of the normal distribution
+        Standard deviation of the normal distribution
     limit : float, optional
-        resample any values more than this distance from the mean. if None,
-        then limit will be set to 2 standard deviations
+        Resample any values more than this distance from the mean. If None,
+        then limit will be set to 2 standard deviations.
     """
 
     mean = NumberParam("mean")
@@ -74,12 +74,12 @@ class VarianceScaling(Distribution):
     Parameters
     ----------
     scale : float, optional
-        overall scale on values
+        Overall scale on values
     mode : "fan_in" or "fan_out" or "fan_avg", optional
-        whether to scale based on input or output dimensionality, or average of
+        Whether to scale based on input or output dimensionality, or average of
         the two
     distribution: "uniform" or "normal", optional
-        whether to use a uniform or normal distribution for weights
+        Whether to use a uniform or normal distribution for weights
     """
 
     scale = NumberParam("scale", low=0)
@@ -141,10 +141,10 @@ class Glorot(VarianceScaling):
     Parameters
     ----------
     scale : float, optional
-        scale on weight distribution. for rectified linear units this should
-        be sqrt(2), otherwise usually 1
+        Scale on weight distribution. For rectified linear units this should
+        be sqrt(2), otherwise usually 1.
     distribution: "uniform" or "normal", optional
-        whether to use a uniform or normal distribution for weights
+        Whether to use a uniform or normal distribution for weights
 
     References
     ----------
@@ -165,10 +165,10 @@ class He(VarianceScaling):
     Parameters
     ----------
     scale : float, optional
-        scale on weight distribution. for rectified linear units this should
-        be sqrt(2), otherwise usually 1
+        Scale on weight distribution. For rectified linear units this should
+        be sqrt(2), otherwise usually 1.
     distribution: "uniform" or "normal", optional
-        whether to use a uniform or normal distribution for weights
+        Whether to use a uniform or normal distribution for weights
 
     References
     ----------

--- a/nengo_dl/graph_optimizer.py
+++ b/nengo_dl/graph_optimizer.py
@@ -25,9 +25,9 @@ def mergeable(op, chosen_ops):
     Parameters
     ----------
     op : :class:`~nengo:nengo.builder.Operator`
-        the operator to be merged
+        The operator to be merged
     chosen_ops : list of :class:`~nengo:nengo.builder.Operator`
-        the operator group to be merged in to
+        The operator group to be merged in to
 
     Returns
     -------
@@ -152,12 +152,12 @@ def greedy_planner(operators):
     Parameters
     ----------
     operators : list of :class:`~nengo:nengo.builder.Operator`
-        all the ``nengo`` operators in a model (unordered)
+        All the ``nengo`` operators in a model (unordered)
 
     Returns
     -------
     list of tuple of :class:`~nengo:nengo.builder.Operator`
-        operators combined into mergeable groups and in execution order
+        Operators combined into mergeable groups and in execution order
 
     Notes
     -----
@@ -235,15 +235,15 @@ def tree_planner(op_list, max_depth=3):
     Parameters
     ----------
     op_list : list of :class:`~nengo:nengo.builder.Operator`
-        all the ``nengo`` operators in a model (unordered)
+        All the ``nengo`` operators in a model (unordered)
     max_depth : int, optional
-        the planner will search this many steps ahead before selecting which
+        The planner will search this many steps ahead before selecting which
         group to schedule next
 
     Returns
     -------
     list of tuple of :class:`~nengo:nengo.builder.Operator`
-        operators combined into mergeable groups and in execution order
+        Operators combined into mergeable groups and in execution order
     """
 
     def shortest_plan(selected, successors_of, predecessors_of, cache,
@@ -385,12 +385,12 @@ def noop_planner(operators):
     Parameters
     ----------
     operators : list of :class:`~nengo:nengo.builder.Operator`
-        all the ``nengo`` operators in a model (unordered)
+        All the ``nengo`` operators in a model (unordered)
 
     Returns
     -------
     list of tuple of :class:`~nengo:nengo.builder.Operator`
-        operators in execution order
+        Operators in execution order
     """
 
     dependency_graph = operator_dependency_graph(operators)
@@ -412,12 +412,12 @@ def transitive_planner(op_list):
     Parameters
     ----------
     op_list : list of :class:`~nengo:nengo.builder.Operator`
-        all the ``nengo`` operators in a model (unordered)
+        All the ``nengo`` operators in a model (unordered)
 
     Returns
     -------
     list of tuple of :class:`~nengo:nengo.builder.Operator`
-        operators combined into mergeable groups and in execution order
+        Operators combined into mergeable groups and in execution order
     """
 
     # note: importing this here since it only exists in nengo 2.4.0
@@ -546,20 +546,20 @@ def transitive_closure_recurse(dg, ops, trans, builder_type, builder_types,
     Parameters
     ----------
     dg : dict of {int: set of int}
-        dependency graph where ``dg[a] = {b, c}`` indicates that operators
+        Dependency graph where ``dg[a] = {b, c}`` indicates that operators
         ``b`` and ``c`` are dependent on ``a``
     ops : list of int
-        the operators for which we want to compute the transitive closure
+        The operators for which we want to compute the transitive closure
     trans : dict of {int: set of int}
-        the transitive closure for the graph (will be filled in-place)
+        The transitive closure for the graph (will be filled in-place)
     builder_type : type
-        one of the ``nengo_dl`` build classes (e.g.,
+        One of the ``nengo_dl`` build classes (e.g.,
         :class:`~.operators.CopyBuilder`), specifying the type of operators
         to include in the transitive closure
     builder_types : list of type
-        the build class for each operator
+        The build class for each operator
     cache : dict of {frozenset of int: set of int}
-        stores base sets which ``trans`` will reference (to reduce memory
+        Stores base sets which ``trans`` will reference (to reduce memory
         usage, since many elements in ``trans`` will have the same value)
 
     Notes
@@ -606,17 +606,17 @@ def order_signals(plan, n_passes=10):
     Parameters
     ----------
     plan : list of tuple of :class:`~nengo:nengo.builder.Operator`
-        operator execution plan (e.g., output from ``greedy_planner``)
+        Operator execution plan (e.g., output from ``greedy_planner``)
     n_passes : int, optional
-        number of repeated passes through the operator reordering stage
+        Number of repeated passes through the operator reordering stage
 
     Returns
     -------
     list of :class:`~nengo:nengo.builder.Signal`
-        signals organized into the order in which we want them arranged in
+        Signals organized into the order in which we want them arranged in
         memory
     list of tuple of :class:`~nengo:nengo.builder.Operator`
-        input plan with operators reordered within groups to align with order
+        Input plan with operators reordered within groups to align with order
         of signals
     """
 
@@ -791,12 +791,12 @@ def hamming_sort(blocks):
     Parameters
     ----------
     blocks : dict of {:class:`~nengo:nengo.builder.Signal`: frozenset of int}
-        dictionary indicating which read blocks each signal is a part of
+        Dictionary indicating which read blocks each signal is a part of
 
     Returns
     -------
     dict of {:class:`~nengo:nengo.builder.Signal`: int}
-        indices indicating where each signal should be in the sorted list
+        Indices indicating where each signal should be in the sorted list
     """
 
     sorted_blocks = []
@@ -899,31 +899,31 @@ def sort_ops_by_signals(sorted_reads, sigs, sig_idxs, new_plan, blocks, reads):
     ----------
     sorted_reads : list of tuple of (:class:`~nengo:nengo.builder.Operator`, \
                                      int)
-        the operators that form each read block, sorted by increasing size of
-        the read block. in the case that a group of operators participate in
+        The operators that form each read block, sorted by increasing size of
+        the read block. In the case that a group of operators participate in
         multiple read blocks, the integer distinguishes which one of those
         inputs this block is associated with.
     sigs : list of :class:`~nengo:nengo.builder.Signal`
-        signals that have been arranged into a given order by other parts
+        Signals that have been arranged into a given order by other parts
         of the algorithm
     sig_idxs : dict of {:class:`~nengo:nengo.builder.Signal`: int}
-        sorted indices of signals
+        Sorted indices of signals
     new_plan : dict of {tuple of :class:`~nengo:nengo.builder.Operator`: \
                         tuple of :class:`~nengo:nengo.builder.Operator`}
-        mapping from original operator group to the sorted operators
+        Mapping from original operator group to the sorted operators
     blocks : dict of {:class:`~nengo:nengo.builder.Signal`: frozenset of int}
-        indicates which read blocks each signal participates in
+        Indicates which read blocks each signal participates in
     reads : dict of {:class:`~nengo:nengo.builder.Operator`: \
                      list of :class:`~nengo:nengo.builder.Signal`}
-        the signals read by each operator
+        The signals read by each operator
 
     Returns
     -------
     new_plan : dict of {tuple of :class:`~nengo:nengo.builder.Operator`: \
                         tuple of :class:`~nengo:nengo.builder.Operator`}
-        mapping from original operator group to the sorted operators
+        Mapping from original operator group to the sorted operators
     sig_idxs : dict of {:class:`~nengo:nengo.builder.Signal`: int}
-        signal indices, possibly updated to match new op order
+        Signal indices, possibly updated to match new op order
     """
 
     logger.log(logging.DEBUG - 1, "sort ops by signals")
@@ -977,27 +977,27 @@ def sort_signals_by_ops(sorted_reads, sigs, sig_idxs, new_plan, blocks, reads):
     ----------
     sorted_reads : list of tuple of (:class:`~nengo:nengo.builder.Operator`, \
                                      int)
-        the operators that form each read block, sorted by increasing size of
-        the read block. in the case that a group of operators participate in
+        The operators that form each read block, sorted by increasing size of
+        the read block. In the case that a group of operators participate in
         multiple read blocks, the integer distinguishes which one of those
         inputs this block is associated with.
     sigs : list of :class:`~nengo:nengo.builder.Signal`
-        signals to be sorted
+        Signals to be sorted
     sig_idxs : dict of {:class:`~nengo:nengo.builder.Signal`: int}
-        sorted indices of signals
+        Sorted indices of signals
     new_plan : dict of {tuple of :class:`~nengo:nengo.builder.Operator`: \
                         tuple of :class:`~nengo:nengo.builder.Operator`}
-        mapping from original operator group to the sorted operators
+        Mapping from original operator group to the sorted operators
     blocks : dict of {:class:`~nengo:nengo.builder.Signal`: frozenset of int}
-        indicates which read blocks each signal participates in
+        Indicates which read blocks each signal participates in
     reads : dict of {:class:`~nengo:nengo.builder.Operator`: \
                      list of :class:`~nengo:nengo.builder.Signal`}
-        the signals read by each operator
+        The signals read by each operator
 
     Returns
     -------
     sig_idxs : dict of {:class:`~nengo:nengo.builder.Signal`: int}
-        sorted indices of signals
+        Sorted indices of signals
     """
 
     logger.log(logging.DEBUG - 1, "-" * 10)
@@ -1071,14 +1071,14 @@ def create_signals(sigs, plan, float_type, minibatch_size):
     Parameters
     ----------
     sigs : list of :class:`~nengo:nengo.builder.Signal`
-        base signals arranged into the order in which they should reside in
+        Base signals arranged into the order in which they should reside in
         memory (e.g., output from ``order_signals``)
     plan : list of tuple of :class:`~nengo:nengo.builder.Operator`
-        operator execution plan (only used to get a list of all the operators)
+        Operator execution plan (only used to get a list of all the operators)
     float_type : ``np.float32`` or ``np.float64``
-        floating point precision to use for signals
+        Floating point precision to use for signals
     minibatch_size : int
-        number of items in each minibatch
+        Number of items in each minibatch
 
     Returns
     -------
@@ -1234,12 +1234,12 @@ def remove_unmodified_resets(operators):
     Parameters
     ----------
     operators : list of :class:`~nengo:nengo.builder.Operator`
-        operators in the model
+        Operators in the model
 
     Returns
     -------
     list of :class:`~nengo:nengo.builder.Operator`
-        modified list of operators
+        Modified list of operators
     """
 
     _, incs, _, updates = signal_io_dicts(operators)
@@ -1270,12 +1270,12 @@ def remove_zero_incs(operators):
     Parameters
     ----------
     operators : list of :class:`~nengo:nengo.builder.Operator`
-        operators in the model
+        Operators in the model
 
     Returns
     -------
     list of :class:`~nengo:nengo.builder.Operator`
-        modified list of operators
+        Modified list of operators
     """
 
     sets, incs, _, updates = signal_io_dicts(operators)
@@ -1367,12 +1367,12 @@ def remove_constant_copies(operators):
     Parameters
     ----------
     operators : list of :class:`~nengo:nengo.builder.Operator`
-        operators in the model
+        Operators in the model
 
     Returns
     -------
     list of :class:`~nengo:nengo.builder.Operator`
-        modified list of operators
+        Modified list of operators
     """
 
     sets, incs, _, updates = signal_io_dicts(operators)
@@ -1438,12 +1438,12 @@ def remove_identity_muls(operators):
     Parameters
     ----------
     operators : list of :class:`~nengo:nengo.builder.Operator`
-        operators in the model
+        Operators in the model
 
     Returns
     -------
     list of :class:`~nengo:nengo.builder.Operator`
-        modified list of operators
+        Modified list of operators
     """
 
     sets, incs, _, updates = signal_io_dicts(operators)
@@ -1499,6 +1499,9 @@ def remove_identity_muls(operators):
 
 
 def signal_io_dicts(operators):
+    """Organizes operators into dictionaries according to the signals they
+    set/inc/read/update."""
+
     # note: we manually initialize the arrays because we want there to be
     # an entry for all the signal bases, but get an error if we try to
     # access any non-base signals

--- a/nengo_dl/neuron_builders.py
+++ b/nengo_dl/neuron_builders.py
@@ -22,7 +22,7 @@ class SimNeuronsBuilder(OpBuilder):
     Attributes
     ----------
     TF_NEURON_IMPL : list of :class:`~nengo:nengo.neurons.NeuronType`
-        the neuron types that have a custom implementation
+        The neuron types that have a custom implementation
     """
 
     TF_NEURON_IMPL = (RectifiedLinear, Sigmoid, LIF, LIFRate, SoftLIFRate)

--- a/nengo_dl/process_builders.py
+++ b/nengo_dl/process_builders.py
@@ -25,7 +25,7 @@ class SimProcessBuilder(OpBuilder):
     Attributes
     ----------
     TF_PROCESS_IMPL : list of :class:`~nengo:nengo.Process`
-        the process types that have a custom implementation
+        The process types that have a custom implementation
     """
 
     TF_PROCESS_IMPL = (Lowpass, LinearFilter)

--- a/nengo_dl/signals.py
+++ b/nengo_dl/signals.py
@@ -15,18 +15,18 @@ class TensorSignal(object):
     Parameters
     ----------
     indices : tuple or list or :class:`~numpy:numpy.ndarray` of int
-        indices along the first axis of the base array corresponding to the
+        Indices along the first axis of the base array corresponding to the
         data for this signal
     key : object
-        key mapping to the base array that contains the data for this signal
+        Key mapping to the base array that contains the data for this signal
     dtype : :class:`~numpy:numpy.dtype`
         dtype of the values represented by this signal
     shape : tuple of int
-        view shape of this signal (may differ from shape of base array)
+        View shape of this signal (may differ from shape of base array)
     minibatched : bool
-        if True then this signal contains a minibatch dimension
+        If True then this signal contains a minibatch dimension
     label : str, optional
-        name for this signal, used to make debugging easier
+        Name for this signal, used to make debugging easier
     """
 
     def __init__(self, indices, key, dtype, shape, minibatched,
@@ -67,12 +67,12 @@ class TensorSignal(object):
         Parameters
         ----------
         indices : slice or list of int
-            the desired subset of the indices in this TensorSignal
+            The desired subset of the indices in this TensorSignal
 
         Returns
         -------
         :class:`.signals.TensorSignal`
-            a new TensorSignal representing the subset of this TensorSignal
+            A new TensorSignal representing the subset of this TensorSignal
         """
 
         if indices is Ellipsis or indices is None:
@@ -91,13 +91,13 @@ class TensorSignal(object):
         Parameters
         ----------
         shape : tuple of int
-            new shape for the signal (one dimension can be -1 to indicate
+            New shape for the signal (one dimension can be -1 to indicate
             an inferred dimension size, as in numpy)
 
         Returns
         -------
         :class:`.signals.TensorSignal`
-            new TensorSignal representing the same data as this signal but
+            New TensorSignal representing the same data as this signal but
             with the given shape
         """
 
@@ -126,10 +126,10 @@ class TensorSignal(object):
         Parameters
         ----------
         axis : 0 or -1
-            where to insert the new dimension (currently only supports either
+            Where to insert the new dimension (currently only supports either
             the beginning or end of the array)
         length : int
-            the number of times to duplicate signal along the broadcast
+            The number of times to duplicate signal along the broadcast
             dimension
 
         Returns
@@ -185,11 +185,11 @@ class SignalDict(object):
     ----------
     sig_map : dict of {:class:`~nengo:nengo.builder.Signal`: \
                        :class:`.TensorSignal`}
-        mapping from ``nengo`` signals to ``nengo_dl`` signals
+        Mapping from ``nengo`` signals to ``nengo_dl`` signals
     dtype : ``tf.DType``
-        floating point precision used in signals
+        Floating point precision used in signals
     minibatch_size : int
-        number of items in each minibatch
+        Number of items in each minibatch
     """
 
     def __init__(self, sig_map, dtype, minibatch_size):
@@ -206,12 +206,12 @@ class SignalDict(object):
         Parameters
         ----------
         dst : :class:`.TensorSignal`
-            signal indicating the data to be modified in base array
+            Signal indicating the data to be modified in base array
         val : ``tf.Tensor``
-            update data (same shape as ``dst``, i.e. a dense array <= the size
+            Update data (same shape as ``dst``, i.e. a dense array <= the size
             of the base array)
         mode : "update" or "inc"
-            overwrite/add the data at ``dst`` with ``val``
+            Overwrite/add the data at ``dst`` with ``val``
         """
 
         if dst.tf_indices is None:
@@ -293,16 +293,16 @@ class SignalDict(object):
         Parameters
         ----------
         src : :class:`.TensorSignal`
-            signal indicating the data to be read from base array
+            Signal indicating the data to be read from base array
         force_copy : bool, optional
-            if True, always perform a gather, not a slice (this forces a
-            copy). note that setting ``force_copy=False`` does not guarantee
+            If True, always perform a gather, not a slice (this forces a
+            copy). Note that setting ``force_copy=False`` does not guarantee
             that a copy won't be performed.
 
         Returns
         -------
         ``tf.Tensor``
-            tensor object corresponding to a dense subset of data from the
+            Tensor object corresponding to a dense subset of data from the
             base array
         """
 
@@ -354,7 +354,7 @@ class SignalDict(object):
         Parameters
         ----------
         src : :class:`.TensorSignal`
-            signal indicating the data being read
+            Signal indicating the data being read
         """
 
         self.gather_bases += [self.bases[src.key]]
@@ -367,17 +367,17 @@ class SignalDict(object):
         ----------
         sigs : list of :class:`.TensorSignal` or \
                        :class:`~nengo:nengo.builder.Signal`
-            signals to be combined
+            Signals to be combined
         load_indices : bool, optional
-            if True, load the indices for the new signal into TensorFlow right
+            If True, load the indices for the new signal into TensorFlow right
             away (otherwise they will need to be manually loaded later)
         label : str, optional
-            name for combined signal (to help with debugging)
+            Name for combined signal (to help with debugging)
 
         Returns
         -------
         :class:`.TensorSignal`
-            new TensorSignal representing the concatenation of the data in
+            New TensorSignal representing the concatenation of the data in
             ``sigs``
         """
 

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -36,28 +36,28 @@ class Simulator(object):
     Parameters
     ----------
     network : :class:`~nengo:nengo.Network` or None
-        a network object to be built and then simulated. If None,
+        A network object to be built and then simulated. If None,
         then a built model must be passed to ``model`` instead
     dt : float, optional
-        length of a simulator timestep, in seconds
+        Length of a simulator timestep, in seconds
     seed : int, optional
-        seed for all stochastic operators used in this simulator
+        Seed for all stochastic operators used in this simulator
     model : :class:`~nengo:nengo.builder.Model`, optional
-        pre-built model object
+        Pre-built model object
     dtype : ``tf.DType``, optional
-        floating point precision to use for simulation
+        Floating point precision to use for simulation
     device : None or ``"/cpu:0"`` or ``"/gpu:[0-n]"``, optional
-        device on which to execute computations (if None then uses the
+        Device on which to execute computations (if None then uses the
         default device as determined by TensorFlow)
     unroll_simulation : int, optional
-        unroll simulation loop by explicitly building the given number of
+        Unroll simulation loop by explicitly building the given number of
         iterations into the computation graph (improves simulation speed
         but increases build time)
     minibatch_size : int, optional
-        the number of simultaneous inputs that will be passed through the
+        The number of simultaneous inputs that will be passed through the
         network
     tensorboard : str, optional
-        if not None, save network output in the TensorFlow summary format to
+        If not None, save network output in the TensorFlow summary format to
         the given directory, which can be loaded into TensorBoard
     """
 
@@ -169,7 +169,7 @@ class Simulator(object):
         Parameters
         ----------
         seed : int, optional
-            if not None, overwrite the default simulator seed with this value
+            If not None, overwrite the default simulator seed with this value
             (note: this becomes the new default simulator seed)
         """
 
@@ -199,10 +199,10 @@ class Simulator(object):
         Parameters
         ----------
         include_trainable : bool, optional
-            if True, also reset any training that has been performed on
+            If True, also reset any training that has been performed on
             network parameters (e.g., connection weights)
         include_probes : bool, optional
-            if True, also clear probe data
+            If True, also clear probe data
         """
 
         init_ops = [self.tensor_graph.local_init_op,
@@ -222,7 +222,7 @@ class Simulator(object):
         Parameters
         ----------
         kwargs : dict
-            see :meth:`.run_steps`
+            See :meth:`.run_steps`
         """
 
         self.run_steps(1, **kwargs)
@@ -233,9 +233,9 @@ class Simulator(object):
         Parameters
         ----------
         time_in_seconds : float
-            amount of time to run the simulation for
+            Run the simulator for the given number of simulated seconds
         kwargs : dict
-            see :meth:`.run_steps`
+            See :meth:`.run_steps`
         """
 
         steps = int(np.round(float(time_in_seconds) / self.dt))
@@ -247,13 +247,13 @@ class Simulator(object):
         Parameters
         ----------
         n_steps : int
-            the number of simulation steps to be executed
+            The number of simulation steps to be executed
         input_feeds : dict of {:class:`~nengo:nengo.Node`: \
                                :class:`~numpy:numpy.ndarray`}
-            override the values of input Nodes with the given data.  arrays
+            Override the values of input Nodes with the given data.  Arrays
             should have shape ``(sim.minibatch_size, n_steps, node.size_out)``.
         profile : bool, optional
-            if True, collect TensorFlow profiling information while the
+            If True, collect TensorFlow profiling information while the
             simulation is running (this will slow down the simulation)
 
         Notes
@@ -337,41 +337,41 @@ class Simulator(object):
         ----------
         inputs : dict of {:class:`~nengo:nengo.Node`: \
                           :class:`~numpy:numpy.ndarray`}
-            input values for Nodes in the network; arrays should have shape
+            Input values for Nodes in the network; arrays should have shape
             ``(batch_size, n_steps, node.size_out)``
         targets : dict of {:class:`~nengo:nengo.Probe`: \
                            :class:`~numpy:numpy.ndarray`}
-            desired output value at Probes, corresponding to each value in
+            Desired output value at Probes, corresponding to each value in
             ``inputs``; arrays should have shape
             ``(batch_size, n_steps, probe.size_in)``
         optimizer : ``tf.train.Optimizer``
-            Tensorflow optimizer, e.g.
+            TensorFlow optimizer, e.g.
             ``tf.train.GradientDescentOptimizer(learning_rate=0.1)``
         n_epochs : int, optional
-            run training for the given number of epochs (complete passes
+            Run training for the given number of epochs (complete passes
             through ``inputs``)
         objective : ``"mse"`` or callable, optional
-            the objective to be minimized. passing ``"mse"`` will train with
-            mean squared error. a custom function
+            The objective to be minimized. Passing ``"mse"`` will train with
+            mean squared error. A custom function
             ``f(output, target) -> loss`` can be passed that consumes the
             actual output and target output for a probe in ``targets``
             and returns a ``tf.Tensor`` representing the scalar loss value for
             that Probe (loss will be averaged across Probes).
         shuffle : bool, optional
-            if True, randomize the data into different minibatches each epoch
+            If True, randomize the data into different minibatches each epoch
         summaries : dict of {str: :class:`~nengo:nengo.Connection` or \
                                   :class:`~nengo:nengo.Ensemble` or \
                                   :class:`~nengo:nengo.ensemble.Neurons` or \
                                   ``"loss"``}, optional
-            if not None, collect data during the training process using
-            TensorFlow's ``tf.summary`` format.  the dictionary should
+            If not None, collect data during the training process using
+            TensorFlow's ``tf.summary`` format.  The dictionary should
             consist of ``{label: obj}`` pairs, where ``obj`` is the object
-            for which we want to collect data.  the object can be a Connection
+            for which we want to collect data.  The object can be a Connection
             (in which case data on the corresponding weights will be
             collected), Ensemble (encoders), Neurons (biases), or ``"loss"``
             (the loss value for ``objective``).
         profile : bool, optional
-            if True, collect TensorFlow profiling information while training
+            If True, collect TensorFlow profiling information while training
             (this will slow down the training)
 
         Notes
@@ -484,20 +484,20 @@ class Simulator(object):
         ----------
         inputs : dict of {:class:`~nengo:nengo.Node`: \
                           :class:`~numpy:numpy.ndarray`}
-            input values for Nodes in the network; arrays should have shape
+            Input values for Nodes in the network; arrays should have shape
             ``(batch_size, n_steps, node.size_out)``
         targets : dict of {:class:`~nengo:nengo.Probe`: \
                            :class:`~numpy:numpy.ndarray`}
-            desired output value at Probes, corresponding to each value in
+            Desired output value at Probes, corresponding to each value in
             ``inputs``; arrays should have shape
             ``(batch_size, n_steps, probe.size_in)``
         objective : ``"mse"`` or callable
-            the objective used to compute loss. passing ``"mse"`` will use
-            mean squared error. a custom function
+            The objective used to compute loss. Passing ``"mse"`` will use
+            mean squared error. A custom function
             ``f(output, target) -> loss`` can be passed that consumes the
             actual output and target output for a probe in ``targets``
             and returns a ``tf.Tensor`` representing the scalar loss value for
-            that Probe (loss will be averaged across Probes)
+            that Probe (loss will be averaged across Probes).
         """
 
         batch_size, n_steps = next(iter(inputs.values())).shape[:2]
@@ -543,11 +543,11 @@ class Simulator(object):
         Parameters
         ----------
         path : str
-            filepath of parameter output file
+            Filepath of parameter output file
         include_global : bool, optional
-            if True (default True), save global (trainable) network variables
+            If True (default True), save global (trainable) network variables
         include_local : bool, optional
-            if True (default False), save local (non-trainable) network
+            If True (default False), save local (non-trainable) network
             variables
         """
         if self.closed:
@@ -571,11 +571,11 @@ class Simulator(object):
         Parameters
         ----------
         path : str
-            filepath of parameter input file
+            Filepath of parameter input file
         include_global : bool, optional
-            if True (default True), load global (trainable) network variables
+            If True (default True), load global (trainable) network variables
         include_local : bool, optional
-            if True (default False), load local (non-trainable) network
+            If True (default False), load local (non-trainable) network
             variables
         """
         if self.closed:
@@ -605,12 +605,12 @@ class Simulator(object):
         ----------
         outputs : ``tf.Tensor`` or list of ``tf.Tensor`` or \
                   list of :class:`~nengo:nengo.Probe`
-            compute gradients wrt this output (if None, computes wrt each
+            Compute gradients wrt this output (if None, computes wrt each
             output probe)
         atol : float, optional
-            absolute error tolerance
+            Absolute error tolerance
         rtol : float, optional
-            relative (to numeric grad) error tolerance
+            Relative (to numeric grad) error tolerance
 
         Notes
         -----
@@ -702,7 +702,7 @@ class Simulator(object):
         Parameters
         ----------
         dt : float, optional
-            the sampling period of the probe to create a range for;
+            The sampling period of the probe to create a range for;
             if None, the simulator's ``dt`` will be used.
         """
 
@@ -739,22 +739,22 @@ class Simulator(object):
         Parameters
         ----------
         n_steps : int
-            the number of execution steps
+            The number of execution steps
         input_feeds : dict of {:class:`~nengo:nengo.Node`: \
                                :class:`~numpy:numpy.ndarray`}
-            override the values of input Nodes with the given data.  arrays
+            Override the values of input Nodes with the given data.  Arrays
             should have shape ``(sim.minibatch_size, n_steps, node.size_out)``.
         targets : dict of {:class:`~nengo:nengo.Probe`: \
                            :class:`~numpy:numpy.ndarray`}, optional
-            values for target placeholders (only necessary if loss is being
+            Values for target placeholders (only necessary if loss is being
             computed, e.g. when training the network)
         start : int, optional
-            initial value of simulator timestep
+            Initial value of simulator timestep
 
         Returns
         -------
         dict of {``tf.Tensor``: :class:`~numpy:numpy.ndarray`}
-            feed values for placeholder tensors in the network
+            Feed values for placeholder tensors in the network
         """
 
         # fill in loop variables
@@ -783,10 +783,15 @@ class Simulator(object):
         ----------
         input_feeds : dict of {:class:`~nengo:nengo.Node`: \
                                :class:`~numpy:numpy.ndarray`}
-            override the values of input Nodes with the given data.  arrays
+            Override the values of input Nodes with the given data.  Arrays
             should have shape ``(sim.minibatch_size, n_steps, node.size_out)``.
         n_steps : int
-            number of simulation timesteps for which to generate input data
+            Number of simulation timesteps for which to generate input data
+
+        Returns
+        -------
+        dict of {:class:`~nengo:nengo.Node`: :class:`~numpy:numpy.ndarray}
+            Simulation values for all the input Nodes in the network.
         """
 
         if input_feeds is None:
@@ -860,11 +865,11 @@ class Simulator(object):
         Parameters
         ----------
         probe_data : list of `np.ndarray`
-            probe data from every timestep
+            Probe data from every timestep
         start : int
-            the simulation timestep at which probe data starts
+            The simulation timestep at which probe data starts
         n_steps : int
-            the number of timesteps over which we want to collect data
+            The number of timesteps over which we want to collect data
         """
 
         # remove any extra timesteps (due to `unroll_simulation` mismatch)
@@ -888,15 +893,15 @@ class Simulator(object):
         data : dict of {:class:`~nengo:nengo.Node` or \
                             :class:`~nengo:nengo.Probe`: \
                         :class:`~numpy:numpy.ndarray`}
-            array of data associated with given objects in model (Nodes if
+            Array of data associated with given objects in model (Nodes if
             mode=="input" or Probes if mode=="target")
         mode : "input" or "target", optional
-            whether this data corresponds to an input or target value
+            Whether this data corresponds to an input or target value
         n_batch : int, optional
-            number of elements in batch (if None, will just verify that all
+            Number of elements in batch (if None, will just verify that all
             data items have same batch size)
         n_steps : int, optional
-            number of simulation steps (if None, will just verify that all
+            Number of simulation steps (if None, will just verify that all
             data items have same number of steps)
         """
 
@@ -981,9 +986,9 @@ class SimulationData(collections.Mapping):
     Parameters
     ----------
     sim : :class:`.Simulator`
-        the simulator from which data will be drawn
+        The simulator from which data will be drawn
     minibatched : bool
-        if False, discard the minibatch dimension on probe data
+        If False, discard the minibatch dimension on probe data
 
     Notes
     -----
@@ -1002,14 +1007,14 @@ class SimulationData(collections.Mapping):
         ----------
         obj : :class:`~nengo:nengo.Probe` or :class:`~nengo:nengo.Ensemble` \
               or :class:`~nengo:nengo.Connection`
-            object whose simulation data is being accessed
+            Object whose simulation data is being accessed
 
         Returns
         -------
         :class:`~numpy:numpy.ndarray` or \
                 :class:`~nengo:nengo.builder.ensemble.BuiltEnsemble` or \
                 :class:`~nengo:nengo.builder.connection.BuiltConnection`
-            array containing probed data if ``obj`` is a
+            Array containing probed data if ``obj`` is a
             :class:`~nengo:nengo.Probe`, otherwise the corresponding
             parameter object
         """
@@ -1068,14 +1073,14 @@ class SimulationData(collections.Mapping):
         Parameters
         ----------
         obj : ``NengoObject``
-            the nengo object for which we want to know the parameters
+            The nengo object for which we want to know the parameters
         attr : str
-            the parameter of ``obj`` to be returned
+            The parameter of ``obj`` to be returned
 
         Returns
         -------
         :class:`~numpy:numpy.ndarray`
-            current value of the parameters associated with the given object
+            Current value of the parameters associated with the given object
 
         Notes
         -----
@@ -1115,16 +1120,16 @@ class SimulationData(collections.Mapping):
         Parameters
         ----------
         obj : ``NengoObject``
-            the nengo object for which we want to know the parameters
+            The nengo object for which we want to know the parameters
         attr : str
-            the parameter of ``obj`` to be returned
+            The parameter of ``obj`` to be returned
 
         Returns
         -------
         obj : ``NengoObject``
-            the nengo object to key into model.sig
+            The nengo object to key into ``model.sig``
         attr : str
-            the name of the signal corresponding to input attr
+            The name of the signal corresponding to input attr
 
         """
 

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -36,20 +36,20 @@ class TensorGraph(object):
     Parameters
     ----------
     model : :class:`~nengo:nengo.builder.Model`
-        pre-built Nengo model describing the network to be simulated
+        Pre-built Nengo model describing the network to be simulated
     dt : float
-        length of a simulator timestep, in seconds
+        Length of a simulator timestep, in seconds
     unroll_simulation : int
-        unroll simulation loop by explicitly building ``unroll_simulation``
+        Unroll simulation loop by explicitly building ``unroll_simulation``
         iterations into the computation graph
     dtype : ``tf.DType``
-        floating point precision to use for simulation
+        Floating point precision to use for simulation
     minibatch_size : int
-        the number of simultaneous inputs that will be passed through the
+        The number of simultaneous inputs that will be passed through the
         network
     device : None or ``"/cpu:0"`` or ``"/gpu:[0-n]"``
-        device on which to execute computations (if None then uses the
-        default device as determined by Tensorflow)
+        Device on which to execute computations (if None then uses the
+        default device as determined by TensorFlow)
     """
 
     def __init__(self, model, dt, unroll_simulation, dtype,
@@ -209,10 +209,10 @@ class TensorGraph(object):
         Returns
         -------
         probe_tensors : list of ``tf.Tensor``
-            the Tensor objects representing the data required for each model
+            The Tensor objects representing the data required for each model
             Probe
         side_effects : list of ``tf.Tensor``
-            the output Tensors of computations that may have side-effects
+            The output Tensors of computations that may have side-effects
             (e.g., :class:`~nengo:nengo.Node` functions), meaning that they
             must be executed each time step even if their output doesn't appear
             to be used in the simulation
@@ -369,7 +369,7 @@ class TensorGraph(object):
 
     def build_inputs(self):
         """Sets up the inputs in the model (which will be computed outside of
-        Tensorflow and fed in each simulation block).
+        TensorFlow and fed in each simulation block).
         """
 
         self.invariant_ph = {}
@@ -391,12 +391,12 @@ class TensorGraph(object):
         Parameters
         ----------
         optimizer : ``tf.train.Optimizer``
-            instance of a Tensorflow optimizer class
+            Instance of a TensorFlow optimizer class
         targets : tuple of :class:`~nengo:nengo.Probe`
-            the Probes corresponding to the output signals being optimized
+            The Probes corresponding to the output signals being optimized
         objective : ``"mse"`` or callable
-            the objective to be minimized. passing ``"mse"`` will train with
-            mean squared error. a custom function
+            The objective to be minimized. Passing ``"mse"`` will train with
+            mean squared error. A custom function
             ``f(output, target) -> loss`` can be passed that consumes the
             actual output and target output for a probe in ``targets``
             and returns a ``tf.Tensor`` representing the scalar loss value for
@@ -405,7 +405,7 @@ class TensorGraph(object):
         Returns
         -------
         ``tf.Tensor``
-            operator implementing the given optimizer update
+            Operator implementing the given optimizer update
         """
 
         loss = self.build_loss(objective, targets)
@@ -433,19 +433,19 @@ class TensorGraph(object):
         Parameters
         ----------
         objective : ``"mse"`` or callable
-            the objective used to compute loss. passing ``"mse"`` will use
-            mean squared error. a custom function
+            The objective used to compute loss. Passing ``"mse"`` will use
+            mean squared error. A custom function
             ``f(output, target) -> loss`` can be passed that consumes the
             actual output and target output for a probe in ``targets``
             and returns a ``tf.Tensor`` representing the scalar loss value for
             that Probe (loss will be averaged across Probes).
         targets : tuple of :class:`~nengo:nengo.Probe`
-            the Probes corresponding to target values in objective
+            The Probes corresponding to target values in objective
 
         Returns
         -------
         ``tf.Tensor``
-            tensor representing the given objective applied to target probes
+            Tensor representing the given objective applied to target probes
         """
 
         if (objective, targets) in self.losses:
@@ -492,9 +492,9 @@ class TensorGraph(object):
         Parameters
         ----------
         sess : ``tf.Session``
-            the TensorFlow session for the simulator
+            The TensorFlow session for the simulator
         rng : :class:`~numpy:numpy.random.RandomState`
-            seeded random number generator
+            Seeded random number generator
         """
 
         for ops, built_ops in self.op_builds.items():
@@ -510,7 +510,7 @@ class TensorGraph(object):
                                   :class:`~nengo:nengo.Connection` or \
                                   :class:`~nengo:nengo.Ensemble` or \
                                   :class:`~nengo:nengo.ensemble.Neurons`}
-            dictionary containing labels for the summary data and the object
+            Dictionary containing labels for the summary data and the object
             for which we want to collect data.  Object can be a Connection (in
             which case data on weights will be collected), Ensemble (encoders),
             Neurons (biases), or a tuple of ``(objective, probes)`` that
@@ -519,7 +519,7 @@ class TensorGraph(object):
         Returns
         -------
         ``tf.Tensor``
-            merged summary op for the given summaries
+            Merged summary op for the given summaries
         """
 
         summary_ops = []
@@ -549,7 +549,7 @@ class TensorGraph(object):
         Parameters
         ----------
         sig : :class:`~nengo:nengo.builder.Signal`
-            a signal in the model
+            A signal in the model
 
         Returns
         -------

--- a/nengo_dl/tensor_node.py
+++ b/nengo_dl/tensor_node.py
@@ -92,14 +92,14 @@ class TensorNode(Node):
     Parameters
     ----------
     tensor_func : callable
-        a function that maps node inputs to outputs
+        A function that maps node inputs to outputs
     size_in : int, optional (Default: 0)
-        the number of elements in the input vector
+        The number of elements in the input vector
     size_out : int, optional (Default: None)
-        the number of elements in the output vector (if None, value will be
+        The number of elements in the output vector (if None, value will be
         inferred by calling ``tensor_func``)
     label : str, optional (Default: None)
-        a name for the node, used for debugging and visualization
+        A name for the node, used for debugging and visualization
     """
 
     tensor_func = TensorFuncParam('tensor_func')
@@ -144,15 +144,15 @@ class SimTensorNode(builder.Operator):
     Parameters
     ----------
     func : callable
-        the TensorNode function (``tensor_func``)
+        The TensorNode function (``tensor_func``)
     time : :class:`~nengo:nengo.builder.Signal`
         Signal representing the current simulation time
     input : :class:`~nengo:nengo.builder.Signal` or None
-        input Signal for the TensorNode (or None if size_in==0)
+        Input Signal for the TensorNode (or None if size_in==0)
     output : :class:`~nengo:nengo.builder.Signal`
-        output Signal for the TensorNode
+        Output Signal for the TensorNode
     tag : str, optional
-        a label associated with the operator, for debugging
+        A label associated with the operator, for debugging
 
     Notes
     -----
@@ -241,13 +241,13 @@ def reshaped(shape_in):
     Parameters
     ----------
     shape_in : tuple of int
-        the desired shape for inputs to the function (not including the first
+        The desired shape for inputs to the function (not including the first
         dimension, which corresponds to the batch axis)
 
     Returns
     -------
     callable
-        the decorated function
+        The decorated function
     """
 
     def reshape_dec(func):
@@ -271,28 +271,28 @@ def tensor_layer(input, layer_func, shape_in=None, synapse=None,
     Parameters
     ----------
     input : :class:`~nengo:nengo.base.NengoObject`
-        object providing input to the layer
+        Object providing input to the layer
     layer_func : callable or :class:`~nengo:nengo.neurons.NeuronType`
-        a function that takes the value from ``input`` (represented as a
-        ``tf.Tensor``) and maps it to some output value. or a Nengo neuron
-        type, defining a nonlinearity that will be applied to ``input``
+        A function that takes the value from ``input`` (represented as a
+        ``tf.Tensor``) and maps it to some output value, or a Nengo neuron
+        type, defining a nonlinearity that will be applied to ``input``.
     shape_in : tuple of int, optional
-        if not None, reshape the input to the given shape
+        If not None, reshape the input to the given shape
     synapse : float or :class:`~nengo:nengo.synapses.Synapse`, optional
-        synapse to apply on connection from ``input`` to this layer
+        Synapse to apply on connection from ``input`` to this layer
     transform : :class:`~numpy:numpy.ndarray`, optional
-        transform matrix to apply on connection from ``input`` to this layer
+        Transform matrix to apply on connection from ``input`` to this layer
     return_conn : bool, optional
-        if True, also return the connection linking this layer to ``input``
+        If True, also return the connection linking this layer to ``input``
     layer_args : dict, optional
-        these arguments will be passed to ``layer_func`` if it is callable, or
+        These arguments will be passed to ``layer_func`` if it is callable, or
         :class:`~nengo:nengo.Ensemble` if ``layer_func`` is a
         :class:`~nengo:nengo.neurons.NeuronType`
 
     Returns
     -------
     :class:`.TensorNode` or :class:`~nengo:nengo.ensemble.Neurons`
-        a TensorNode that implements the given layer function (if
+        A TensorNode that implements the given layer function (if
         ``layer_func`` was a callable), or a Neuron object with the given
         neuron type, connected to ``input``
     """

--- a/nengo_dl/utils.py
+++ b/nengo_dl/utils.py
@@ -23,17 +23,17 @@ if sys.version_info < (3, 4):
 def sanitize_name(name):
     """Remove illegal TensorFlow name characters from string.
 
-    Valid Tensorflow name characters are ``[A-Za-z0-9_.\\-/]``
+    Valid TensorFlow name characters are ``[A-Za-z0-9_.\\-/]``
 
     Parameters
     ----------
     name : str
-        name to be sanitized
+        Name to be sanitized
 
     Returns
     -------
     str
-        sanitized name
+        Sanitized name
     """
 
     if not isinstance(name, str):
@@ -53,14 +53,14 @@ def function_name(func, sanitize=True):
     Parameters
     ----------
     func : callable
-        callable object (e.g., function, callable class)
+        Callable object (e.g., function, callable class)
     sanitize : bool, optional
-        if True, remove any illegal TensorFlow name characters from name
+        If True, remove any illegal TensorFlow name characters from name
 
     Returns
     -------
     str
-        (sanitized) name of ``func``
+        Name of ``func`` (optionally sanitized)
     """
 
     name = getattr(func, "__name__", func.__class__.__name__)
@@ -77,10 +77,10 @@ def align_func(output_shape, output_dtype):
     Parameters
     ----------
     output_shape : tuple of int
-        desired shape for function output (must have the same size as actual
+        Desired shape for function output (must have the same size as actual
         function output)
     output_dtype : ``tf.DType`` or :class:`~numpy:numpy.dtype`
-        desired dtype of function output
+        Desired dtype of function output
 
     Raises
     ------
@@ -118,15 +118,15 @@ def print_op(input, message):
     Parameters
     ----------
     input : ``tf.Tensor``
-        the value of this tensor will be printed whenever it is computed
+        The value of this tensor will be printed whenever it is computed
         in the graph
     message : str
-        string prepended to the value of ``input``, to help with logging
+        String prepended to the value of ``input``, to help with logging
 
     Returns
     -------
     ``tf.Tensor``
-        new tensor representing the print operation applied to ``input``
+        New tensor representing the print operation applied to ``input``
 
     Notes
     -----
@@ -154,14 +154,14 @@ def cast_dtype(dtype, target):
     Parameters
     ----------
     dtype : ``tf.DType`` or :class:`~numpy:numpy.dtype`
-        input dtype to be converted
+        Input dtype to be converted
     target : ``tf.DType``
-        floating point dtype to which all floating types should be converted
+        Floating point dtype to which all floating types should be converted
 
     Returns
     -------
     ``tf.DType``
-        input dtype, converted to ``target`` type if necessary
+        Input dtype, converted to ``target`` type if necessary
     """
 
     if not isinstance(dtype, tf.DType):
@@ -181,10 +181,11 @@ def find_non_differentiable(inputs, outputs):
     Parameters
     ----------
     inputs : list of ``tf.Tensor``
-        input tensors
+        Input tensors
     outputs : list of ``tf.Tensor``
-        output tensors
+        Output tensors
     """
+
     for o in outputs:
         if o in inputs:
             continue
@@ -212,9 +213,9 @@ class ProgressBar(object):
     Parameters
     ----------
     max_steps : int
-        number of steps required to complete the tracked process
+        Number of steps required to complete the tracked process
     label : str, optional
-        a description of what is being tracked
+        A description of what is being tracked
     """
 
     def __init__(self, max_steps, label=None):
@@ -254,7 +255,7 @@ class ProgressBar(object):
         Parameters
         ----------
         msg : str, optional
-            display the given string at the end of the progress bar
+            Display the given string at the end of the progress bar
         """
 
         self.curr_step += 1
@@ -293,28 +294,28 @@ def minibatch_generator(inputs, targets, minibatch_size, shuffle=True,
     ----------
     inputs : dict of {:class:`~nengo:nengo.Node`: \
                       :class:`~numpy:numpy.ndarray`}
-        input values for Nodes in the network
+        Input values for Nodes in the network
     targets : dict of {:class:`~nengo:nengo.Probe`: \
                        :class:`~numpy:numpy.ndarray`}
-        desired output value at Probes, corresponding to each value in
+        Desired output value at Probes, corresponding to each value in
         ``inputs``
     minibatch_size : int
-        the number of items in each minibatch
+        The number of items in each minibatch
     shuffle : bool, optional
-        if True, the division of items into minibatches will be randomized each
+        If True, the division of items into minibatches will be randomized each
         time the generator is created
     rng : :class:`~numpy:numpy.random.RandomState`, optional
-        random number generator
+        Seeded random number generator
 
     Yields
     ------
     inputs : dict of {:class:`~nengo:nengo.Node`: \
                       :class:`~numpy:numpy.ndarray`}
-        the same structure as ``inputs``, but with each array reduced to
+        The same structure as ``inputs``, but with each array reduced to
         ``minibatch_size`` elements along the first dimension
     targets : dict of {:class:`~nengo:nengo.Probe`: \
                        :class:`~numpy:numpy.ndarray`}
-        the same structure as ``targets``, but with each array reduced to
+        The same structure as ``targets``, but with each array reduced to
         ``minibatch_size`` elements along the first dimension
     """
 

--- a/nengo_dl/utils.py
+++ b/nengo_dl/utils.py
@@ -229,7 +229,7 @@ class ProgressBar(object):
 
         self.curr_step = 0
         self.start_time = time.time()
-        self.progress = -1
+        self.last_time = -1
 
         print("[%s] ETA: unknown" % (" " * self.width), end="", flush=True)
 
@@ -259,20 +259,24 @@ class ProgressBar(object):
 
         self.curr_step += 1
 
-        tmp = int(self.width * self.curr_step / self.max_steps)
-        if tmp > self.progress:
-            self.progress = tmp
-        else:
-            return
+        curr_time = time.time()
 
-        eta = int((time.time() - self.start_time) *
+        # only update the progress bar once every second
+        if curr_time - self.last_time < 1:
+            return
+        else:
+            self.last_time = curr_time
+
+        progress = int(self.width * self.curr_step / self.max_steps)
+
+        eta = int((curr_time - self.start_time) *
                   (self.max_steps - self.curr_step) / self.curr_step)
 
-        line = "\r[%s%s] ETA: %s" % ("#" * self.progress,
-                                     " " * (self.width - self.progress),
+        line = "\r[%s%s] ETA: %s" % ("#" * progress,
+                                     " " * (self.width - progress),
                                      datetime.timedelta(seconds=eta))
         if msg is not None or self.label is not None:
-            line += " (%s)" % self.label if msg is None else msg
+            line += " (%s)" % (self.label if msg is None else msg)
 
         print(line, end="", flush=True)
 


### PR DESCRIPTION
Adds support for collecting data from the model during ``sim.train``, using the ``summaries`` argument.  See the updated documentation (``training.rst``) for usage details.