### PR TITLE
Use `tf.data` for training data pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,10 +21,14 @@ Release History
 0.5.3 (unreleased)
 ------------------
 
+**Changed**
+
+- Use ``tf.data`` for training data pipeline (improves training speed).
+
 **Fixed**
 
 - Fixed a bug where input nodes that were only read as a view were not
-  feedable
+  feedable.
 - Updated ``tensorflow-gpu`` installation check
 
 0.5.2 (October 11, 2017)

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -358,7 +358,7 @@ def test_generate_inputs(Simulator, seed):
     with Simulator(net, minibatch_size=2, unroll_simulation=3) as sim:
         feed = sim._generate_inputs({inp[0]: np.zeros((2, 3, 1))}, 3)
 
-        ph = [sim.tensor_graph.invariant_ph[x] for x in inp]
+        ph = [sim.tensor_graph.data_phs[x] for x in inp]
 
         assert len(sim.tensor_graph.invariant_inputs) == len(inp)
         assert len(feed) == len(inp)
@@ -366,13 +366,13 @@ def test_generate_inputs(Simulator, seed):
         sim.reset()
         sim.run_steps(3, input_feeds={inp[0]: np.zeros((2, 3, 1))})
 
-        vals = [np.zeros((3, 1, 2)),
-                np.tile(np.sin(sim.trange())[:, None, None], (1, 1, 2)),
-                np.tile(proc.run_steps(3)[:, :, None], (1, 1, 2)),
-                np.ones((3, 1, 2)) * 2]
+        vals = [np.zeros((2, 3, 1)),
+                np.tile(np.sin(sim.trange())[None, :, None], (2, 1, 1)),
+                np.tile(proc.run_steps(3)[None, :, :], (2, 1, 1)),
+                np.ones((2, 3, 1)) * 2]
         for i, x in enumerate(vals):
             assert np.allclose(feed[ph[i]], x)
-            assert np.allclose(sim.data[p[i]], x.transpose(2, 0, 1))
+            assert np.allclose(sim.data[p[i]], x)
 
 
 def test_save_load_params(Simulator, tmpdir):


### PR DESCRIPTION
Creating this PR as a record for this branch, in case we want to return to it later.

This uses the new `tf.data` API to feed in data during `sim.train` (rather than using `feed_dicts` to feed in data for each training step).  This is, in theory, TensorFlow's recommended way of feeding in data for this kind of situation, but in practice it was slower than the `feed_dicts` approach.

Basically, our training pipeline is already quite fast since all of our training data resides in memory.  So the new API doesn't speed things up much, and it introduces some extra overhead for setting up the input pipelines, which outweighs any benefits.

However, this may be worth revisiting if a) there are further improvements made to the `tf.data` implementation or b) we want to add functionality for more complex input pipelines (e.g. reading data from files).