### PR TITLE
Implement scatter_mul gradients

### DIFF
--- a/nengo_dl/signals.py
+++ b/nengo_dl/signals.py
@@ -276,12 +276,20 @@ class SignalDict(object):
                 len(dst.indices) == var.get_shape()[0]):
             if mode == "inc":
                 result = tf.assign_add(var, src)
-            else:
+            elif mode == "update":
                 result = tf.assign(var, src)
+            elif mode == "mul":
+                result = tf.scatter_mul(var, dst.tf_indices, src)
+            else:
+                raise NotImplementedError
         elif mode == "inc":
             result = tf.scatter_add(var, dst.tf_indices, src)
-        else:
+        elif mode == "update":
             result = tf.scatter_update(var, dst.tf_indices, src)
+        elif mode == "mul":
+            result = tf.scatter_mul(var, dst.tf_indices, src)
+        else:
+            raise NotImplementedError
 
         # result = gen_state_ops._destroy_temporary_variable(var, var_name)
 

--- a/nengo_dl/tests/test_tensorflow_patch.py
+++ b/nengo_dl/tests/test_tensorflow_patch.py
@@ -58,15 +58,22 @@ def test_state_grads():
 
     with tf.Session() as sess:
         v = tf.Variable([0., 0., 0.])
-        x = tf.ones((1,))
+        x = tf.ones((1,)) * 2
         y0 = tf.scatter_update(v, [0], x)
         y1 = tf.scatter_add(v, [0], x)
+        y2 = tf.scatter_mul(v, [0], x)
 
         grad0 = tf.gradients(y0, [v._ref(), x])
         grad1 = tf.gradients(y1, [v._ref(), x])
-        grad_vals = sess.run((grad0, grad1))
+        grad2 = tf.gradients(y2, [v._ref(), x])
+
+        assert grad2[1] is None
+        grad2 = [grad2[0]]
+
+        grad_vals = sess.run((grad0, grad1, grad2))
 
         assert np.allclose(grad_vals[0][0], [0, 1, 1])
         assert np.allclose(grad_vals[0][1], 1)
         assert np.allclose(grad_vals[1][0], 1)
         assert np.allclose(grad_vals[1][1], 1)
+        assert np.allclose(grad_vals[2][0], [2, 1, 1])


### PR DESCRIPTION
Creating this PR as a record for this branch, in case we want to return to it later.

This adds gradient implementations for `tf.scatter_mul` (same idea as with `scatter_update` or `scatter_add`).  However, not merging this in because 1) the only place it is used is in LowpassBuilder, and it doesn't seem to provide any significant performance benefits there and 2) there doesn't seem to be an efficient way to implement the gradient in the `IndexedSlices` case.

However, this may be worth revisiting in the future if we add new ops that could utilize `scatter_mul`.