### PR TITLE
Added meta connection op

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Release History
   scales the output in the same way as the new ``amplitude`` parameter in
   ``LIF``/``LIFRate`` (see `Nengo PR #1325
   <https://github.com/nengo/nengo/pull/1325>`_).
+- Added new meta-Operators to the `nengo_dl` build process, which improve
+  simulation/training speed.
 
 **Changed**
 

--- a/nengo_dl/graph_optimizer.py
+++ b/nengo_dl/graph_optimizer.py
@@ -14,7 +14,8 @@ from nengo.utils.simulator import operator_dependency_graph
 import numpy as np
 
 from nengo_dl import (signals, process_builders, builder, tensor_node,
-                      op_builders, learning_rule_builders, neuron_builders)
+                      op_builders, learning_rule_builders, neuron_builders,
+                      meta_builders)
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +141,13 @@ def mergeable(op, chosen_ops):
         attr = ("pre_decoded" if isinstance(op, SimVoja) else
                 "pre_filtered")
         if getattr(op, attr).shape[0] != getattr(c, attr).shape[0]:
+            return False
+    elif isinstance(op, meta_builders.SimConnection):
+        # the sub-ops in the fused op most all be mergeable
+        if len(op.ops) != len(c.ops):
+            return False
+
+        if not all(mergeable(a, [b]) for a, b in zip(op.ops, c.ops)):
             return False
 
     return True

--- a/nengo_dl/meta_builders.py
+++ b/nengo_dl/meta_builders.py
@@ -1,0 +1,194 @@
+import copy
+from collections import deque
+import logging
+import warnings
+
+from nengo import builder, Connection
+from nengo.builder.operator import ElementwiseInc, DotInc, Reset
+from nengo.builder.processes import SimProcess
+from nengo.exceptions import SimulationError
+from nengo.synapses import LinearFilter
+import tensorflow as tf
+
+from nengo_dl import op_builders, process_builders
+from nengo_dl.builder import Builder, OpBuilder
+
+logger = logging.getLogger(__name__)
+
+
+class CaptureOps(object):
+    def __init__(self, model):
+        self.captured_ops = []
+        self.model = model
+
+    def __getattr__(self, attr):
+        if attr in ("model", "captured_ops", "add_op", "build"):
+            return super(CaptureOps, self).__getattr__(attr)
+        else:
+            return getattr(self.model, attr)
+
+    def add_op(self, op):
+        self.captured_ops.append(op)
+
+    def build(self, obj, *args, **kwargs):
+        return self.builder.build(self, obj, *args, **kwargs)
+
+
+def build_connection(model, conn):
+    if (not getattr(model, "_in_nengo_dl", False) or
+            conn.learning_rule is not None):
+        # TODO: make learning rules work with SimConnection
+        # for complicated connections we just fall back on the normal builder
+        builder.connection.build_connection(model, conn)
+    else:
+        # build the connection into our dummy model that captures all the
+        # operators
+        capture_model = CaptureOps(model)
+        builder.connection.build_connection(capture_model, conn)
+
+        # we only build SimConnection up to the second last op, since that is
+        # where the connection is probeable and where the synapse update
+        # occurs. so add the last op back into the regular model.
+        model.add_op(capture_model.captured_ops.pop())
+
+        op = SimConnection(conn, capture_model.captured_ops,
+                           model.time)
+        model.add_op(op)
+
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=UserWarning)
+    builder.Builder.register(Connection)(build_connection)
+
+
+class SimConnection(builder.Operator):
+    """Operator that combines all the computations of a connection into a
+    single op.
+    """
+
+    def __init__(self, conn, ops, time, tag=None):
+        super(SimConnection, self).__init__(tag=str(conn))
+
+        # we drop the reset ops, since they are never used
+        self.ops = [o for o in ops if not isinstance(o, Reset)]
+        self.conn = conn
+
+        # collect external inputs/outputs from all ops in chain
+        remaining_ops = deque(o for o in self.ops)
+
+        # op is the first simpyfunc/dotinc/copy
+        op = remaining_ops.popleft()
+        reads = [o for o in op.reads]
+
+        # add in the weights for the dotinc (if they weren't added above)
+        if not isinstance(op, (ElementwiseInc, DotInc)):
+            op = remaining_ops.popleft()
+            reads.append(op.A)
+
+        try:
+            op = remaining_ops.popleft()
+
+            # if there is an op left it should be a synapse
+            assert isinstance(op, SimProcess)
+
+            # some processes may need to read the sim time
+            if not isinstance(op.process, LinearFilter):
+                reads.append(time)
+
+            outputs = op.updates
+            is_update = True
+        except IndexError:
+            outputs = op.incs
+            is_update = False
+
+        self.sets = [] if is_update else outputs
+        self.incs = []
+        self.reads = reads
+        self.updates = outputs if is_update else []
+
+    def make_step(self, *args, **kwargs):
+        """``make_step`` is never called by the NengoDL simulator, so if this
+        is called it means that someone is trying to execute this op in
+        some other Simulator."""
+
+        def error():
+            raise SimulationError("SimConnection can only be simulated in the "
+                                  "NengoDL simulator")
+
+        return error
+
+
+@Builder.register(SimConnection)
+class SimConnectionBuilder(OpBuilder):
+    def __init__(self, ops, signals):
+        super(SimConnectionBuilder, self).__init__(ops, signals)
+
+        logger.debug([str(o) for o in zip(*[op.ops for op in ops])])
+
+        self.prebuilt_ops = deque(
+            Builder.builders[type(o[0])](o, signals)
+            for o in zip(*[op.ops for op in ops]))
+
+    def build_step(self, signals):
+        remaining_ops = copy.copy(self.prebuilt_ops)
+        simpyfunc_out = None
+
+        logger.debug("building simconnection")
+        logger.debug("\n".join(str(o) for o in remaining_ops))
+
+        op_builder = remaining_ops.popleft()
+
+        if isinstance(op_builder, op_builders.SimPyFuncBuilder):
+            # apply simpyfunc (if pre is a direct ensemble)
+            x = signals.gather(op_builder.input_data)
+            x = op_builder._step([], x)
+            simpyfunc_out = x
+
+            op_builder = remaining_ops.popleft()
+        elif isinstance(op_builder, op_builders.CopyBuilder):
+            # apply copy slice (if pre_slice is an advanced index)
+            x = signals.gather(op_builder.src_data)
+
+            op_builder = remaining_ops.popleft()
+        else:
+            # gather input from the first weight dotinc op
+            # TODO: why is this force copy necessary?
+            x = signals.gather(op_builder.X_data, force_copy=True)
+
+        # multiply by connection weights
+        logger.debug("applying weights")
+        assert isinstance(op_builder, (op_builders.ElementwiseIncBuilder,
+                                       op_builders.DotIncBuilder))
+        X_shape = op_builder.X_data.shape + (signals.minibatch_size,)
+        Y_shape = op_builder.Y_data.shape + (signals.minibatch_size,)
+        if x.get_shape() != X_shape:
+            x = tf.reshape(x, X_shape)
+        x = op_builder._step(signals.gather(op_builder.A_data), x)
+        if x.get_shape() != Y_shape:
+            x = tf.reshape(x, Y_shape)
+
+        try:
+            # apply synapse if there is one for this connection
+            op_builder = remaining_ops.popleft()
+
+            assert isinstance(op_builder, process_builders.SimProcessBuilder)
+
+            logger.debug("applying synapse")
+
+            if isinstance(op_builder.built_process,
+                          process_builders.GenericProcessBuilder):
+                x = op_builder.built_process._step(signals.time, x)
+            else:
+                x = op_builder.built_process._step(x, signals)
+
+            signals.scatter(op_builder.built_process.output_data, x)
+        except IndexError:
+            signals.scatter(op_builder.Y_data, x)
+
+        assert len(remaining_ops) == 0
+
+        return simpyfunc_out
+
+    def build_post(self, ops, *args):
+        for i, op_builder in enumerate(self.prebuilt_ops):
+            op_builder.build_post(tuple(o.ops[i] for o in ops), *args)

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -114,6 +114,8 @@ class Simulator(object):
                               "dt (%g)" % (model.dt, dt), NengoWarning)
             self.model = model
 
+        self.model._in_nengo_dl = True
+
         if network is not None:
             print("Building network", end="", flush=True)
             start = time.time()


### PR DESCRIPTION
Creating this PR as a record for this branch, in case we want to return to it later.

The idea here is to gather the individual operators that make up a Connection into a single "meta" operator, in order to reduce the overhead associated with small ops (we could apply the same idea to ensembles).

I'm not pursuing this any further for now, because this initial implementation has not shown significant performance benefits.  The main challenge seems to be that the meta ops make it more difficult to merge ops horizontally (i.e., merging parallel SimConnection ops), because they require that all the operators within the meta op be mergeable.  So the benefits gained from combining all the ops within a connection are cancelled out by the fact that we can't merge ops across connections as effectively.

However, it seems likely that there are still benefits to be gained by this idea, with some more effort put into optimizing SimConnection.  They're likely to be relatively minor improvements which is why I'm tabling this for now, but it's an idea worth revisiting if we have time in the future.